### PR TITLE
Allow custom validators to be specified just by key and the payload to be passed in as validation data

### DIFF
--- a/modules/cbvalidation/models/ValidationManager.cfc
+++ b/modules/cbvalidation/models/ValidationManager.cfc
@@ -140,9 +140,7 @@ component accessors="true" serialize="false" implements="IValidationManager" sin
 		// process the incoming rules
 		for( var key in arguments.rules ){
 			// if message validators, just ignore
-			if( reFindNoCase( "^(#replace( variables.validValidators, ",", "|", "all" )#)Message$", key ) ){ continue; }
-			// if not in list, ignore
-			if( !listFindNoCase( variables.validValidators, key ) ){ continue; }
+			if( reFindNoCase( "Message$", key ) ){ continue; }
 
 			// had to use nasty evaluate until adobe cf get's their act together on invoke.
 			getValidator( validatorType=key, validationData=arguments.rules[ key ] )
@@ -181,6 +179,7 @@ component accessors="true" serialize="false" implements="IValidationManager" sin
 				return wirebox.getInstance( arguments.validationData );
 			}
 			default : {
+				if ( wirebox.getBinder().mappingExists( validatorType ) ) { return wirebox.getInstance( validatorType ); }
 				throw(message="The validator you requested #arguments.validatorType# is not a valid validator",type="ValidationManager.InvalidValidatorType");
 			}
 		}


### PR DESCRIPTION
This pull requests makes a few things possible:

1. Nicer naming of custom validators
2. Multiple custom validators per key
3. Passing arbitrary data to a custom validator encouraging reusability

My use case: an `ExistsInDBValidator` (not using ORM).  I need to specify a table and a column.  I’d like the validator itself to be reusable.

The only way I’ve seen now is to use a bunch of extra info in the validator string and then parse it in the custom validator (provided as the `validationData` argument.

```js
this.constraints = {
    itemNumber = {
        validator = "id:ExistsInDBValiadator:table_name:column_name"
    }
};
```

This pull request makes the following possible:

```js
this.constraints = {
    itemNumber = {
        existsInDBValidator = {
            table = "table_name",
            column = "column_name"
        }
    }
};
```