### PR TITLE
Switch evaluate for invoke

### DIFF
--- a/modules/cbvalidation/models/ValidationManager.cfc
+++ b/modules/cbvalidation/models/ValidationManager.cfc
@@ -175,7 +175,7 @@ component accessors="true" serialize="false" implements="IValidationManager" sin
 					validationResult = results,
 					target           = arguments.target,
 					field            = arguments.field,
-					targetValue      = invoke( arguments.target, "get" & arguments.field )
+					targetValue      = invoke( arguments.target, "get" & arguments.field ),
 					validationData   = arguments.rules[ key ]
 				);
 

--- a/modules/cbvalidation/models/ValidationManager.cfc
+++ b/modules/cbvalidation/models/ValidationManager.cfc
@@ -172,11 +172,11 @@ component accessors="true" serialize="false" implements="IValidationManager" sin
 			// had to use nasty evaluate until adobe cf get's their act together on invoke.
 			getValidator( validatorType=key, validationData=arguments.rules[ key ] )
 				.validate(
-					validationResult	= results,
-					target				= arguments.target,
-					field				= arguments.field,
-					targetValue			= evaluate( "arguments.target.get#arguments.field#()" ),
-					validationData		= arguments.rules[ key ]
+					validationResult = results,
+					target           = arguments.target,
+					field            = arguments.field,
+					targetValue      = invoke( arguments.target, "get" & arguments.field )
+					validationData   = arguments.rules[ key ]
 				);
 
 		}


### PR DESCRIPTION
I'm not sure what ACF compatibility issue there was, but it doesn't seem to be present in ACF 11.  Evaluate also has the downside of changing case of the called function on Lucee (something that was messing up my `onMissingMethod` calls).